### PR TITLE
add `chap --version`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,15 +22,15 @@ repos:
   rev: v1.1.2
   hooks:
   - id: reuse
-- repo: https://github.com/pycqa/pylint
-  rev: v2.17.0
-  hooks:
-  - id: pylint
-    additional_dependencies: [click,dataclasses_json,httpx,lorem-text,'textual>=0.18.0',websockets]
-    args: ['--source-roots', 'src']
 - repo: https://github.com/pycqa/isort
   rev: 5.12.0
   hooks:
     - id: isort
       name: isort (python)
       args: ['--profile', 'black']
+- repo: https://github.com/pycqa/pylint
+  rev: v2.17.0
+  hooks:
+  - id: pylint
+    additional_dependencies: [click,dataclasses_json,httpx,lorem-text,'textual>=0.18.0',websockets]
+    args: ['--source-roots', 'src']

--- a/src/chap/__main__.py
+++ b/src/chap/__main__.py
@@ -24,7 +24,10 @@ def version_callback(ctx, param, value) -> None:  # pylint: disable=unused-argum
             encoding="utf-8",
         )
     else:
-        from .__version__ import __version__ as version
+        try:
+            from .__version__ import __version__ as version
+        except ImportError:
+            version = "unknown"
     prog_name = ctx.find_root().info_name
     click.utils.echo(
         f"{prog_name}, version {version}",

--- a/src/chap/__main__.py
+++ b/src/chap/__main__.py
@@ -1,13 +1,36 @@
 # SPDX-FileCopyrightText: 2023 Jeff Epler <jepler@gmail.com>
 #
 # SPDX-License-Identifier: MIT
+# pylint: disable=import-outside-toplevel
 
 import importlib
+import pathlib
 import pkgutil
+import subprocess
 
 import click
 
 from . import commands  # pylint: disable=no-name-in-module
+
+
+def version_callback(ctx, param, value) -> None:  # pylint: disable=unused-argument
+    if not value or ctx.resilient_parsing:
+        return
+
+    git_dir = pathlib.Path(__file__).parent.parent.parent / ".git"
+    if git_dir.exists():
+        version = subprocess.check_output(
+            ["git", f"--git-dir={git_dir}", "describe", "--tags", "--dirty"],
+            encoding="utf-8",
+        )
+    else:
+        from .__version__ import __version__ as version
+    prog_name = ctx.find_root().info_name
+    click.utils.echo(
+        f"{prog_name}, version {version}",
+        color=ctx.color,
+    )
+    ctx.exit()
 
 
 class MyCLI(click.MultiCommand):
@@ -27,7 +50,18 @@ class MyCLI(click.MultiCommand):
             raise click.UsageError(f"Invalid subcommand {cmd_name!r}", ctx) from exc
 
 
-main = click.version_option()(MyCLI(help="Commandline interface to ChatGPT"))
+main = MyCLI(
+    help="Commandline interface to ChatGPT",
+    params=[
+        click.Option(
+            ("--version",),
+            is_flag=True,
+            is_eager=True,
+            help="Show the version and exit",
+            callback=version_callback,
+        )
+    ],
+)
 
 if __name__ == "__main__":
     main()

--- a/src/chap/__main__.py
+++ b/src/chap/__main__.py
@@ -27,7 +27,7 @@ class MyCLI(click.MultiCommand):
             raise click.UsageError(f"Invalid subcommand {cmd_name!r}", ctx) from exc
 
 
-main = MyCLI(help="Commandline interface to ChatGPT")
+main = click.version_option()(MyCLI(help="Commandline interface to ChatGPT"))
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
A `__version__` file is already created/managed by setuptools_scm. I'm not wedded to this tool, I chose it out of familiarity.

click has an easy way to add a `--version` flag, though the way to apply it to a MultiCommand is opaque.

For now I make version numbers just by using the "draft a new release" function on the github website. I do intend to adhere to semver, if I ever feel like this reaches a "version 1" status, fwiw.

Closes: #6

@peterkaminski I can't directly request review from you but wouldn't mind you taking a look since you expressed the idea in the first place.