### PR TITLE
Support backend parameters via `-B name:value`

### DIFF
--- a/src/chap/__main__.py
+++ b/src/chap/__main__.py
@@ -1,70 +1,8 @@
 # SPDX-FileCopyrightText: 2023 Jeff Epler <jepler@gmail.com>
 #
 # SPDX-License-Identifier: MIT
-# pylint: disable=import-outside-toplevel
 
-import importlib
-import pathlib
-import pkgutil
-import subprocess
-
-import click
-
-from . import commands  # pylint: disable=no-name-in-module
-
-
-def version_callback(ctx, param, value) -> None:  # pylint: disable=unused-argument
-    if not value or ctx.resilient_parsing:
-        return
-
-    git_dir = pathlib.Path(__file__).parent.parent.parent / ".git"
-    if git_dir.exists():
-        version = subprocess.check_output(
-            ["git", f"--git-dir={git_dir}", "describe", "--tags", "--dirty"],
-            encoding="utf-8",
-        )
-    else:
-        try:
-            from .__version__ import __version__ as version
-        except ImportError:
-            version = "unknown"
-    prog_name = ctx.find_root().info_name
-    click.utils.echo(
-        f"{prog_name}, version {version}",
-        color=ctx.color,
-    )
-    ctx.exit()
-
-
-class MyCLI(click.MultiCommand):
-    def list_commands(self, ctx):
-        rv = []
-        for pi in pkgutil.walk_packages(commands.__path__):
-            name = pi.name
-            if not name.startswith("__"):
-                rv.append(name)
-        rv.sort()
-        return rv
-
-    def get_command(self, ctx, cmd_name):
-        try:
-            return importlib.import_module("." + cmd_name, commands.__name__).main
-        except ModuleNotFoundError as exc:
-            raise click.UsageError(f"Invalid subcommand {cmd_name!r}", ctx) from exc
-
-
-main = MyCLI(
-    help="Commandline interface to ChatGPT",
-    params=[
-        click.Option(
-            ("--version",),
-            is_flag=True,
-            is_eager=True,
-            help="Show the version and exit",
-            callback=version_callback,
-        )
-    ],
-)
+from .core import main
 
 if __name__ == "__main__":
     main()

--- a/src/chap/backends/lorem.py
+++ b/src/chap/backends/lorem.py
@@ -4,6 +4,7 @@
 
 import asyncio
 import random
+from dataclasses import dataclass
 
 from lorem_text import lorem
 
@@ -18,6 +19,16 @@ def ipartition(s, sep=" "):
 
 
 class Lorem:
+    @dataclass
+    class Parameters:
+        delay_mu: float = 0.035
+        delay_sigma: float = 0.02
+        paragraph_lo: int = 1
+        paragraph_hi: int = 5
+
+    def __init__(self):
+        self.parameters = self.Parameters()
+
     system_message = (
         "(It doesn't matter what you ask, this backend will respond with lorem)"
     )
@@ -26,12 +37,16 @@ class Lorem:
         data = self.ask(session, query, max_query_size=max_query_size, timeout=timeout)
         for word, opt_sep in ipartition(data):
             yield word + opt_sep
-            await asyncio.sleep(random.uniform(0.02, 0.05))
+            await asyncio.sleep(
+                random.gauss(self.parameters.delay_mu, self.parameters.delay_sigma)
+            )
 
     def ask(
         self, session, query, *, max_query_size=5, timeout=60
     ):  # pylint: disable=unused-argument
-        new_content = lorem.paragraphs(3).replace("\n", "\n\n")
+        new_content = lorem.paragraphs(
+            random.randint(self.parameters.paragraph_lo, self.parameters.paragraph_hi)
+        ).replace("\n", "\n\n")
         session.session.extend([User(query), Assistant("".join(new_content))])
         return new_content
 

--- a/src/chap/backends/openai_chatgpt.py
+++ b/src/chap/backends/openai_chatgpt.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: MIT
 
 import json
+from dataclasses import dataclass
 
 import httpx
 
@@ -11,19 +12,22 @@ from ..session import Assistant, Session, User
 
 
 class ChatGPT:
+    @dataclass
+    class Parameters:
+        model: str = "gpt-3.5-turbo"
+
     def __init__(self):
-        pass
+        self.parameters = self.Parameters()
 
     system_message: str = "You're named Chap (they/them). Chap strives to answer truthfully and frankly. You have opinions, preferences, and emotions, you can say when you don't know, and you prefer to speak in plain language."
 
     def ask(self, session, query, *, max_query_size=5, timeout=60):
         full_prompt = Session(session.session + [User(query)])
         del full_prompt.session[1:-max_query_size]
-
         response = httpx.post(
             "https://api.openai.com/v1/chat/completions",
             json={
-                "model": "gpt-3.5-turbo",
+                "model": self.parameters.model,
                 "messages": full_prompt.to_dict()[  # pylint: disable=no-member
                     "session"
                 ],
@@ -33,7 +37,6 @@ class ChatGPT:
             },
             timeout=timeout,
         )
-
         if response.status_code != 200:
             print("Failure", response.status_code, response.text)
             return None
@@ -60,7 +63,7 @@ class ChatGPT:
                     "https://api.openai.com/v1/chat/completions",
                     headers={"authorization": f"Bearer {self.get_key()}"},
                     json={
-                        "model": "gpt-3.5-turbo",
+                        "model": self.parameters.model,
                         "stream": True,
                         "messages": full_prompt.to_dict()[  # pylint: disable=no-member
                             "session"

--- a/src/chap/commands/cat.py
+++ b/src/chap/commands/cat.py
@@ -4,23 +4,15 @@
 
 import click
 
-from ..core import last_session_path
-from ..session import Session
+from ..core import uses_existing_session
 
 
 @click.command
-@click.option("--session", "-s", type=click.Path(exists=True), default=None)
-@click.option("--last", is_flag=True)
+@uses_existing_session
 @click.option("--no-system", is_flag=True)
-def main(session, last, no_system):
+def main(obj, no_system):
     """Print session in plaintext"""
-    if bool(session) + bool(last) != 1:
-        raise SystemExit("Specify either --session, or --last")
-
-    if last:
-        session = last_session_path()
-    with open(session, "r", encoding="utf-8") as f:
-        session = Session.from_json(f.read())  # pylint: disable=no-member
+    session = obj.session
 
     first = True
     for row in session.session:

--- a/src/chap/commands/cat.py
+++ b/src/chap/commands/cat.py
@@ -11,7 +11,8 @@ from ..session import Session
 @click.command
 @click.option("--session", "-s", type=click.Path(exists=True), default=None)
 @click.option("--last", is_flag=True)
-def main(session, last):
+@click.option("--no-system", is_flag=True)
+def main(session, last, no_system):
     """Print session in plaintext"""
     if bool(session) + bool(last) != 1:
         raise SystemExit("Specify either --session, or --last")
@@ -26,7 +27,20 @@ def main(session, last):
         if not first:
             print()
         first = False
-        print(row.content)
+        if row.role == "user":
+            decoration = "**"
+        elif row.role == "system":
+            if no_system:
+                continue
+            decoration = "_"
+        else:
+            decoration = ""
+
+        content = row.content.strip()
+        if "\n" in content:
+            print(content)
+        else:
+            print(f"{decoration}{content}{decoration}")
 
 
 if __name__ == "__main__":

--- a/src/chap/commands/cat.py
+++ b/src/chap/commands/cat.py
@@ -28,7 +28,7 @@ def main(obj, no_system):
         else:
             decoration = ""
 
-        content = row.content.strip()
+        content = str(row.content).strip()
         if "\n" in content:
             print(content)
         else:

--- a/src/chap/commands/grep.py
+++ b/src/chap/commands/grep.py
@@ -31,9 +31,10 @@ def list_files_matching_rx(
 
 @click.command
 @click.option("--ignore-case", "-i", is_flag=True)
+@click.option("--files-with-matches", "-l", is_flag=True)
 @click.option("--fixed-strings", "--literal", "-F", is_flag=True)
 @click.argument("pattern", nargs=1, required=True)
-def main(ignore_case, fixed_strings, pattern):
+def main(ignore_case, files_with_matches, fixed_strings, pattern):
     """Search sessions for pattern"""
     console = rich.get_console()
     if fixed_strings:
@@ -43,14 +44,19 @@ def main(ignore_case, fixed_strings, pattern):
     last_file = None
     for f, m in list_files_matching_rx(rx, ignore_case):
         if f != last_file:
-            if last_file:
-                print()
-            console.print(f"[bold]{f}[nobold]:")
+            if files_with_matches:
+                print(f)
+            else:
+                if last_file:
+                    print()
+                console.print(f"[bold]{f}[nobold]:")
             last_file = f
         else:
-            console.print("[dim]---[nodim]")
-        m.content, _ = rx.subn(lambda p: f"**{p.group(0)}**", m.content)
-        console.print(to_markdown(m))
+            if not files_with_matches:
+                console.print("[dim]---[nodim]")
+        if not files_with_matches:
+            m.content, _ = rx.subn(lambda p: f"**{p.group(0)}**", m.content)
+            console.print(to_markdown(m))
 
 
 if __name__ == "__main__":

--- a/src/chap/commands/grep.py
+++ b/src/chap/commands/grep.py
@@ -25,7 +25,7 @@ def list_files_matching_rx(
         with open(conversation, "r", encoding="utf-8") as f:
             session = Session.from_json(f.read())  # pylint: disable=no-member
             for message in session.session:
-                if rx.search(message.content):
+                if isinstance(message.content, str) and rx.search(message.content):
                     yield conversation, message
 
 

--- a/src/chap/commands/render.py
+++ b/src/chap/commands/render.py
@@ -7,8 +7,7 @@ import rich
 from markdown_it import MarkdownIt
 from rich.markdown import Markdown
 
-from ..core import last_session_path
-from ..session import Session
+from ..core import uses_existing_session
 
 
 def to_markdown(message):
@@ -27,18 +26,11 @@ def to_markdown(message):
 
 
 @click.command
-@click.option("--session", "-s", type=click.Path(exists=True), default=None)
-@click.option("--last", is_flag=True)
+@uses_existing_session
 @click.option("--no-system", is_flag=True)
-def main(session, last, no_system):
+def main(obj, no_system):
     """Print session with formatting"""
-    if bool(session) + bool(last) != 1:
-        raise SystemExit("Specify either --session, or --last")
-
-    if last:
-        session = last_session_path()
-    with open(session, "r", encoding="utf-8") as f:
-        session = Session.from_json(f.read())  # pylint: disable=no-member
+    session = obj.session
 
     console = rich.get_console()
     first = True

--- a/src/chap/commands/render.py
+++ b/src/chap/commands/render.py
@@ -29,7 +29,8 @@ def to_markdown(message):
 @click.command
 @click.option("--session", "-s", type=click.Path(exists=True), default=None)
 @click.option("--last", is_flag=True)
-def main(session, last):
+@click.option("--no-system", is_flag=True)
+def main(session, last, no_system):
     """Print session with formatting"""
     if bool(session) + bool(last) != 1:
         raise SystemExit("Specify either --session, or --last")
@@ -45,6 +46,8 @@ def main(session, last):
         if not first:
             console.print()
         first = False
+        if no_system and row.role == "system":
+            continue
         console.print(to_markdown(row))
 
 

--- a/src/chap/commands/render.py
+++ b/src/chap/commands/render.py
@@ -21,7 +21,7 @@ def to_markdown(message):
     m = Markdown("", style=style)
     parser = MarkdownIt()
     parser.options["html"] = False
-    m.parsed = parser.parse(message.content.strip())
+    m.parsed = parser.parse(str(message.content).strip())
     return m
 
 

--- a/src/chap/commands/tui.py
+++ b/src/chap/commands/tui.py
@@ -103,6 +103,7 @@ class Tui(App):
             output._markdown = all_output  # pylint: disable=protected-access
             self.container.scroll_end()
             self.input.disabled = False
+            self.input.focus()
 
     def scroll_end(self):
         self.call_after_refresh(self.container.scroll_end)

--- a/src/chap/commands/tui.py
+++ b/src/chap/commands/tui.py
@@ -13,7 +13,7 @@ from textual.binding import Binding
 from textual.containers import Container, VerticalScroll
 from textual.widgets import Footer, Input, Markdown
 
-from ..core import get_api, last_session_path, new_session_path
+from ..core import get_api, uses_new_session
 from ..session import Assistant, Session, User
 
 
@@ -115,29 +115,12 @@ class Tui(App):
 
 
 @click.command
-@click.option("--continue-session", "-s", type=click.Path(exists=True), default=None)
-@click.option("--last", is_flag=True)
-@click.option("--new-session", "-n", type=click.Path(exists=False), default=None)
-@click.option("--system-message", "-S", type=str, default=None)
-@click.option("--backend", "-b", type=str, default="openai_chatgpt")
-def main(continue_session, last, new_session, system_message, backend):
+@uses_new_session
+def main(obj):
     """Start interactive terminal user interface session"""
-    if bool(continue_session) + bool(last) + bool(new_session) > 1:
-        raise SystemExit(
-            "--continue-session, --last and --new_session are mutually exclusive"
-        )
-
-    api = get_api(backend)
-
-    if last:
-        continue_session = last_session_path()
-    if continue_session:
-        session_filename = continue_session
-        with open(session_filename, "r", encoding="utf-8") as f:
-            session = Session.from_json(f.read())  # pylint: disable=no-member
-    else:
-        session_filename = new_session_path(new_session)
-        session = Session.new_session(system_message or api.system_message)
+    api = obj.api
+    session = obj.session
+    session_filename = obj.session_filename
 
     tui = Tui(api, session)
     tui.run()

--- a/src/chap/core.py
+++ b/src/chap/core.py
@@ -1,11 +1,20 @@
 # SPDX-FileCopyrightText: 2023 Jeff Epler <jepler@gmail.com>
 #
 # SPDX-License-Identifier: MIT
+# pylint: disable=import-outside-toplevel
 
 import datetime
 import importlib
+import pathlib
+import pkgutil
+import subprocess
+from dataclasses import dataclass
 
+import click
 import platformdirs
+
+from . import commands  # pylint: disable=no-name-in-module
+from .session import Session
 
 conversations_path = platformdirs.user_state_path("chap") / "conversations"
 conversations_path.mkdir(parents=True, exist_ok=True)
@@ -35,3 +44,158 @@ def ask(*args, **kw):
 
 def aask(*args, **kw):
     return get_api().aask(*args, **kw)
+
+
+def do_session_continue(ctx, param, value):
+    if value is None:
+        return
+    if ctx.obj.session is not None:
+        raise click.BadParameter(
+            param, "--continue-session, --last and --new-session are mutually exclusive"
+        )
+    with open(value, "r", encoding="utf-8") as f:
+        ctx.obj.session = Session.from_json(f.read())  # pylint: disable=no-member
+    ctx.obj.session_filename = value
+
+
+def do_session_last(ctx, param, value):  # pylint: disable=unused-argument
+    if not value:
+        return
+    do_session_continue(ctx, param, last_session_path())
+
+
+def do_session_new(ctx, param, value):
+    if ctx.obj.session is not None:
+        if value is None:
+            return
+        raise click.BadOptionUsage(
+            param, "--continue-session, --last and --new-session are mutually exclusive"
+        )
+    session_filename = new_session_path(value)
+    system_message = ctx.obj.system_message or ctx.obj.api.system_message
+    ctx.obj.session = Session.new_session(system_message)
+    ctx.obj.session_filename = session_filename
+
+
+def set_system_message(ctx, param, value):  # pylint: disable=unused-argument
+    ctx.obj.system_message = value
+
+
+def set_backend(ctx, param, value):  # pylint: disable=unused-argument
+    ctx.obj.api = get_api(value)
+
+
+def uses_session(f):
+    f = click.option(
+        "--continue-session",
+        "-s",
+        type=click.Path(exists=True),
+        default=None,
+        callback=do_session_continue,
+        expose_value=False,
+    )(f)
+    f = click.option(
+        "--last", is_flag=True, callback=do_session_last, expose_value=False
+    )(f)
+    f = click.pass_obj(f)
+    return f
+
+
+def uses_existing_session(f):
+    f = uses_session(f)
+    return f
+
+
+def uses_new_session(f):
+    f = click.option(
+        "--system-message",
+        "-S",
+        type=str,
+        default=None,
+        callback=set_system_message,
+        expose_value=False,
+    )(f)
+    f = click.option(
+        "--backend",
+        "-b",
+        type=str,
+        default="openai_chatgpt",
+        callback=set_backend,
+        expose_value=False,
+    )(f)
+    f = uses_existing_session(f)
+    f = click.option(
+        "--new-session",
+        "-n",
+        type=click.Path(exists=False),
+        default=None,
+        callback=do_session_new,
+        expose_value=False,
+    )(f)
+    return f
+
+
+def version_callback(ctx, param, value) -> None:  # pylint: disable=unused-argument
+    if not value or ctx.resilient_parsing:
+        return
+
+    git_dir = pathlib.Path(__file__).parent.parent.parent / ".git"
+    if git_dir.exists():
+        version = subprocess.check_output(
+            ["git", f"--git-dir={git_dir}", "describe", "--tags", "--dirty"],
+            encoding="utf-8",
+        )
+    else:
+        try:
+            from .__version__ import __version__ as version
+        except ImportError:
+            version = "unknown"
+    prog_name = ctx.find_root().info_name
+    click.utils.echo(
+        f"{prog_name}, version {version}",
+        color=ctx.color,
+    )
+    ctx.exit()
+
+
+@dataclass
+class Obj:
+    api: object = None
+    system_message: object = None
+    session: Session | None = None
+
+
+class MyCLI(click.MultiCommand):
+    def make_context(self, info_name, args, parent=None, **extra):
+        result = super().make_context(info_name, args, parent, **extra)
+        result.obj = Obj()
+        return result
+
+    def list_commands(self, ctx):
+        rv = []
+        for pi in pkgutil.walk_packages(commands.__path__):
+            name = pi.name
+            if not name.startswith("__"):
+                rv.append(name)
+        rv.sort()
+        return rv
+
+    def get_command(self, ctx, cmd_name):
+        try:
+            return importlib.import_module("." + cmd_name, commands.__name__).main
+        except ModuleNotFoundError as exc:
+            raise click.UsageError(f"Invalid subcommand {cmd_name!r}", ctx) from exc
+
+
+main = MyCLI(
+    help="Commandline interface to ChatGPT",
+    params=[
+        click.Option(
+            ("--version",),
+            is_flag=True,
+            is_eager=True,
+            help="Show the version and exit",
+            callback=version_callback,
+        )
+    ],
+)


### PR DESCRIPTION
.. and expose some for lorem & chatgpt

eventually the never-used parameters about max_query_size and timeout
will be moved to backend parameters, but the main thing was to add
the ability to access gpt4:

```
$ chap ask -b openai_chatgpt -B model:gpt-4 is gpt4 smarter than gpt3.5
is gpt4 smarter than gpt3.5

As of my knowledge at this time, GPT-4 doesn't exist. Perhaps in the future,
there will be a successor to GPT-3. Usually, each newer version of a model like
this is designed to be more powerful and sophisticated, so it would likely be
"smarter" than GPT-3. However, since it doesn't currently exist, I can't make a
definite comparison.
```

:grin:
