### PR TITLE
chap tui: add ability to cancel generation with escape key

### DIFF
--- a/src/chap/commands/tui.css
+++ b/src/chap/commands/tui.css
@@ -39,9 +39,13 @@ Markdown {
 Footer {
     dock: top;
 }
-Input {
+
+#inputbox {
     dock: bottom;
+    height: 3;
 }
+
+#inputbox Button { dock: right; display: none; }
 
 Markdown {
     margin: 0 1 0 0;


### PR DESCRIPTION
also reduces jank during the initial load; the app is mounted with all conversation displayed & scrolled to the bottom.