### PR TITLE
Show code blocks at full height

### DIFF
--- a/src/chap/commands/tui.css
+++ b/src/chap/commands/tui.css
@@ -36,6 +36,9 @@ Markdown:focus-within {
 Markdown {
     border-left: heavy transparent;
 }
+MarkdownFence {
+    max-height: 9999;
+}
 Footer {
     dock: top;
 }


### PR DESCRIPTION
...well, for any reasonable height anyway.

When scrollbars appear the refreshing output tends to get janky, so just allow the code region (called a fence in markdown, apparently) to be up to 9999 lines tall.